### PR TITLE
Karlburke/move base image to python3.13

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Parent image
-FROM redhat/ubi9:9.4
+FROM redhat/ubi10:latest
 
 LABEL description="HuBMAP API Docker Base Image, Python 3.13 for uwsgi apps"
 
@@ -9,6 +9,11 @@ WORKDIR /tmp
 # configuration commands which follow.
 COPY ./verify_install.sh .
 RUN chmod 755 ./verify_install.sh
+
+# Stick a shell script in the image which verifies the system Python version is
+# still available, but uWSGI runs with Python 3.13.
+COPY ./verify_uwsgi.sh .
+RUN chmod 755 ./verify_uwsgi.sh
 
 # When trying to run "update" or "install" commands using dnf or yum the
 # "system is not registered with an entitlement server" error message is given.
@@ -20,6 +25,22 @@ enabled=0
 # When following option is set to 1, then all repositories defined outside redhat.repo will be disabled
 # every time subscription-manager plugin is triggered by dnf or yum
 disable_system_repos=0
+EOF
+
+# Configure global dnf behavior to disable installation of weak dependencies and
+# documentation globally to minimize image size, while preserving Red Hat defaults that
+# help avoid breakage when upgrading packages.
+# Configure global DNF behavior for smaller image layers
+RUN set -eux && \
+    cat <<'EOF' > /etc/dnf/dnf.conf
+[main]
+gpgcheck=1
+installonly_limit=3
+clean_requirements_on_remove=True
+best=True
+skip_if_unavailable=True
+install_weak_deps=False
+tsflags=nodocs
 EOF
 
 # Reduce the number of layers in image by minimizing the number of separate RUN commands
@@ -35,38 +56,70 @@ EOF
 
 # Install OS packages needed for the rest of this configuration and for
 # operations while running services in uWSGI.
-RUN set -eux && \
-    dnf upgrade --assumeyes && \
-    dnf install --assumeyes dnf-plugins-core && \
-    dnf install --assumeyes gcc git && \
-    dnf install --assumeyes make wget openssl-devel bzip2-devel libffi-devel && \
-    dnf install --assumeyes zlib-devel xz-devel procps-ng && \
-    dnf clean all 
-
 # Install using Python 3.13 and the packages needed for services to run in uWSGI
 RUN set -eux && \
+    # Install what is needed to retrieve and build Python for uWSGI, and to execute uWSGI
+    dnf upgrade --assumeyes && \
+    dnf install --assumeyes dnf-plugins-core && \
+    dnf install --assumeyes gcc && \
+    dnf install --assumeyes make wget openssl-devel bzip2-devel libffi-devel && \
+    dnf install --assumeyes zlib-devel xz-devel procps-ng && \
     cd /usr/local/src && \
     wget https://www.python.org/ftp/python/3.13.9/Python-3.13.9.tgz && \
     tar xzf Python-3.13.9.tgz && \
     cd Python-3.13.9 && \
-    ./configure --enable-optimizations --prefix=/usr/local/python3.13 && \
-    make -j$(nproc) && make altinstall && \
-    ln -sf /usr/local/python3.13/bin/pip3.13 /usr/local/bin/pip3.13 && \
+    # Use --without-ensurepip to disable test suite installation, but
+    # then manually install pip using get-pip.py.
+    ./configure --enable-optimizations \
+                --without-ensurepip \
+		--without-tests \
+		--prefix=/usr/local/python3.13 && \
+    make -j$(nproc) && \
+    make altinstall && \
+    make clean && \
+    # Remove debug symbols from Python 3.13
+    strip /usr/local/python3.13/bin/python3.13 && \
+    # Manually install pip
+    wget https://bootstrap.pypa.io/get-pip.py && \
+    /usr/local/python3.13/bin/python3.13 get-pip.py && \
+    # Soft link the Python for uWSGI to a location in the typical
+    # PATH, and next do the system Python used by dnf.
     ln -sf /usr/local/python3.13/bin/python3.13 /usr/local/bin/python3.13 && \
-    wget https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm && \
-    dnf install --assumeyes ./epel-release-latest-9.noarch.rpm && \
-    dnf config-manager --set-disabled epel && \
+    ln -sf /usr/local/python3.13/bin/pip3.13 /usr/local/bin/pip3.13 && \
+    # Add the Extra Packages for Enterprise Linux repository while python3.13-devel is not
+    # available in the standard UBI 10 base AppStream repository
+    wget --quiet https://dl.fedoraproject.org/pub/epel/epel-release-latest-10.noarch.rpm && \
+    dnf install --assumeyes ./epel-release-latest-10.noarch.rpm && \
     dnf install --assumeyes --enablerepo=epel python3.13-devel && \
+    # Install the Python package the services need to run uWSGI, and its dependencies
     /usr/local/bin/pip3.13 install --root-user-action=ignore --no-cache-dir --upgrade pip wheel uwsgi && \
-    rm -rf /usr/local/src/Python-3.13.9*
+    # Empty out the __pycache__ directories of new Python installation to minimize the size of
+    # this Image layer.  Expect running Containers to refill as they start Python
+    find /usr/local/python3.13 -type d -name '__pycache__' -exec rm -rf {} + && \
+    # Remove the EPEL repo and clean up other artifacts to slim down this layer of the Docker Image
+    dnf remove --assumeyes epel-release && \
+    dnf remove --assumeyes make wget gcc && \
+    dnf remove --assumeyes python-devel openssl-devel bzip2-devel libffi-devel zlib-devel xz-devel procps-ng && \
+    dnf autoremove --assumeyes && \
+    dnf clean all && \
+    rm -f /etc/yum.repos.d/epel*.repo && \
+    rm -rf /usr/local/src/Python-3.13.9* \
+           /usr/local/python3.13/lib/python3.13/test \
+           /usr/local/python3.13/lib/python3.13/ensurepip \
+           /var/cache/dnf \
+           /var/log/dnf \
+           /var/log/yum \
+	   /root/.cache
 
 # Register Python 3.13 with 'alternatives' so that it has higher
 # priority than the system default.  Also make sure it is aliased as
 # 'python3' for shell users by via a uwsgi-affiliated script.
 RUN set -eux && \
-    alternatives --install /usr/bin/python3 python3 /usr/bin/python3.9 10 && \
-    alternatives --install /usr/bin/python3 python3 /usr/local/bin/python3.13 20 && \
-    # make 'python3' point to 3.13 only for uwsgi and app processes && \
+    # Keep system python (3.12) as default for dnf/yum
+    alternatives --install /usr/bin/python3 python3 /usr/bin/python3.12 20 && \
+    # Register python3.13, but lower priority so it's not the default
+    alternatives --install /usr/bin/python3 python3 /usr/local/bin/python3.13 10 && \
+    # make 'python3' point to 3.13 using aliases only for uwsgi and app shells && \
     echo 'alias python3=/usr/local/bin/python3.13' >> /etc/profile.d/uwsgi_python.sh && \
     echo 'alias python=/usr/local/bin/python3.13' >> /etc/profile.d/uwsgi_python.sh && \
     echo 'alias pip3=/usr/local/bin/pip3.13' >> /etc/profile.d/uwsgi_python.sh && \
@@ -76,16 +129,19 @@ RUN set -eux && \
 # remove packages which were only needed by the preceding steps and not by
 # services running in uWSGI.
 RUN set -eux && \
-    dnf install --assumeyes procps-ng make && \
-    git clone https://github.com/ncopa/su-exec.git /tmp/su-exec && \
-    cd su-exec && \
-    make && \
-    mv su-exec /usr/local/bin/ && \
-    chmod a+x /usr/local/bin/su-exec && \
-    cd /tmp && \
-    rm -Rf /tmp/su-exec/ && \
-    # N.B. git and gcc are needed for su-exec installation, but
-    #      also must remain for uwsgi, so do not remove like
-    #      compilation-only packages.
-    dnf remove --assumeyes make wget && \
-    dnf clean all
+    # Install what is needed to retrieve and build su-exec
+    dnf install --assumeyes procps-ng make gcc git wget && \
+    # Fetch the latest commit without any history
+    git clone --depth 1 https://github.com/ncopa/su-exec.git /tmp/su-exec && \
+    # Build and install su-exec
+    make -C /tmp/su-exec && \
+    install -m 755 /tmp/su-exec/su-exec /usr/local/bin/su-exec && \
+    # Clean up artifacts to slim down this layer of the Docker Image
+    dnf remove --assumeyes procps-ng make gcc git wget && \
+    dnf autoremove --assumeyes && \
+    dnf clean all && \
+    rm -rf /tmp/su-exec \
+           /var/cache/dnf \
+           /var/log/dnf \
+           /var/log/yum \
+	   /root/.cache

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Parent image
-FROM redhat/ubi10:latest
+FROM redhat/ubi10:10.0
 
 LABEL description="HuBMAP API Docker Base Image, Python 3.13 for uwsgi apps"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,8 +30,8 @@ EOF
 #          place at /usr/libexec/platform-python.
 # 3 - Ensure pip is available, upgraded, and aliased 
 # 4 - Pip install wheel and uwsgi packages globally using pip3.13. Pip uses wheel to install uwsgi
-# KBKBKB @TODO - Build and install su-exec for privilege drop
-# 5 - Remove apps not needed in image, clean up yum cache to reduce size and vulnerabilities
+# 5 - Build and install su-exec for privilege drop
+# 6 - Remove apps not needed in image, clean up yum cache to reduce size and vulnerabilities
 
 # Install OS packages needed for the rest of this configuration and for
 # operations while running services in uWSGI.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,36 +1,82 @@
 # Parent image
 FROM redhat/ubi9:9.4
 
-LABEL description="HuBMAP API Docker Base Image"
+LABEL description="HuBMAP API Docker Base Image, Python 3.13 for uwsgi apps"
 
-# When trying to run "yum updates" or "yum install" the "system is not registered with an entitlement server" error message is given
-# To fix this issue:
-RUN echo $'[main]\n\
-enabled=0\n\\n\
-# When following option is set to 1, then all repositories defined outside redhat.repo will be disabled\n\
-# every time subscription-manager plugin is triggered by dnf or yum\n\
-disable_system_repos=0\n'\
->> /etc/yum/pluginconf.d/subscription-manager.conf
+WORKDIR /tmp
+
+# Stick a shell script into the image which does verification of the
+# configuration commands which follow.
+COPY ./verify_install.sh .
+RUN chmod 755 ./verify_install.sh
+
+# When trying to run "update" or "install" commands using dnf or yum the
+# "system is not registered with an entitlement server" error message is given.
+# Avoid subscription-manager entitlement errors by configuring the subscription manager:
+RUN set -eux && \
+    cat <<EOF > /etc/dnf/plugins/subscription-manager.conf
+[main]
+enabled=0
+# When following option is set to 1, then all repositories defined outside redhat.repo will be disabled
+# every time subscription-manager plugin is triggered by dnf or yum
+disable_system_repos=0
+EOF
 
 # Reduce the number of layers in image by minimizing the number of separate RUN commands
-# 1 - Install GCC, Git, Python 3.9, libraries needed for Python development, and pcre needed by uwsgi
-# 2 - Set default Python version for `python` command, `python3` already points to the newly installed Python3.9
-# 3 - Upgrade pip, after upgrading, both pip and pip3 are the same version
-# 4 - Pip install wheel and uwsgi packages. Pip uses wheel to install uwsgi
-# 5 - Clean all yum cache
+# 1 - Install GCC, Git, Python 3.13, libraries needed for Python development, and pcre needed by uwsgi
+# 2 - Set default Python version for `python` and `python3` commands.
+#     N.B. Leave the Python native to the UBI for
+#          system utilities like `dnf` and `yum` in
+#          place at /usr/libexec/platform-python.
+# 3 - Ensure pip is available, upgraded, and aliased 
+# 4 - Pip install wheel and uwsgi packages globally using pip3.13. Pip uses wheel to install uwsgi
+# KBKBKB @TODO - Build and install su-exec for privilege drop
+# 5 - Remove apps not needed in image, clean up yum cache to reduce size and vulnerabilities
 
-RUN yum update -y && \
-    yum install -y yum-utils && \
-    yum install -y gcc git python python-devel && \
-    python -m ensurepip --upgrade && \
-    pip install wheel uwsgi && \
-    yum clean all 
+# Install OS packages needed for the rest of this configuration and for
+# operations while running services in uWSGI.
+RUN set -eux && \
+    dnf upgrade --assumeyes && \
+    dnf install --assumeyes dnf-plugins-core && \
+    dnf install --assumeyes gcc git && \
+    dnf install --assumeyes make wget openssl-devel bzip2-devel libffi-devel && \
+    dnf install --assumeyes zlib-devel xz-devel procps-ng && \
+    dnf clean all 
 
-# Install su-exec for de-elevating root to deepphe user
-# N.B. git and gcc are also needed for su-exec installation, but since already
-#      added for uwsgi, they are simply used and are not removed like compilation-only packages.
-WORKDIR /tmp
-RUN yum install --assumeyes  procps-ng make && \
+# Install using Python 3.13 and the packages needed for services to run in uWSGI
+RUN set -eux && \
+    cd /usr/local/src && \
+    wget https://www.python.org/ftp/python/3.13.9/Python-3.13.9.tgz && \
+    tar xzf Python-3.13.9.tgz && \
+    cd Python-3.13.9 && \
+    ./configure --enable-optimizations --prefix=/usr/local/python3.13 && \
+    make -j$(nproc) && make altinstall && \
+    ln -sf /usr/local/python3.13/bin/pip3.13 /usr/local/bin/pip3.13 && \
+    ln -sf /usr/local/python3.13/bin/python3.13 /usr/local/bin/python3.13 && \
+    wget https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm && \
+    dnf install --assumeyes ./epel-release-latest-9.noarch.rpm && \
+    dnf config-manager --set-disabled epel && \
+    dnf install --assumeyes --enablerepo=epel python3.13-devel && \
+    /usr/local/bin/pip3.13 install --root-user-action=ignore --no-cache-dir --upgrade pip wheel uwsgi && \
+    rm -rf /usr/local/src/Python-3.13.9*
+
+# Register Python 3.13 with 'alternatives' so that it has higher
+# priority than the system default.  Also make sure it is aliased as
+# 'python3' for shell users by via a uwsgi-affiliated script.
+RUN set -eux && \
+    alternatives --install /usr/bin/python3 python3 /usr/bin/python3.9 10 && \
+    alternatives --install /usr/bin/python3 python3 /usr/local/bin/python3.13 20 && \
+    # make 'python3' point to 3.13 only for uwsgi and app processes && \
+    echo 'alias python3=/usr/local/bin/python3.13' >> /etc/profile.d/uwsgi_python.sh && \
+    echo 'alias python=/usr/local/bin/python3.13' >> /etc/profile.d/uwsgi_python.sh && \
+    echo 'alias pip3=/usr/local/bin/pip3.13' >> /etc/profile.d/uwsgi_python.sh && \
+    echo 'alias pip=/usr/local/bin/pip3.13' >> /etc/profile.d/uwsgi_python.sh
+
+# Install su-exec for de-elevating root to hive user while running services, and
+# remove packages which were only needed by the preceding steps and not by
+# services running in uWSGI.
+RUN set -eux && \
+    dnf install --assumeyes procps-ng make && \
     git clone https://github.com/ncopa/su-exec.git /tmp/su-exec && \
     cd su-exec && \
     make && \
@@ -38,5 +84,8 @@ RUN yum install --assumeyes  procps-ng make && \
     chmod a+x /usr/local/bin/su-exec && \
     cd /tmp && \
     rm -Rf /tmp/su-exec/ && \
-    yum remove --assumeyes make && \
-    yum clean all
+    # N.B. git and gcc are needed for su-exec installation, but
+    #      also must remain for uwsgi, so do not remove like
+    #      compilation-only packages.
+    dnf remove --assumeyes make wget && \
+    dnf clean all

--- a/verify_install.sh
+++ b/verify_install.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+set -euo pipefail
+trap 'echo "Error: command failed on line $LINENO: $BASH_COMMAND" >&2' ERR
+
+# Declare an associative array keyed by the generic package name to install, with
+# a value of all the architecture packages expected to be found if installed.
+declare -A package_map
+package_map[dnf-plugins-core]="dnf-plugins-core.noarch"
+package_map[gcc]="gcc.x86_64"
+package_map[git]="git.x86_64 git-core.x86_64"
+package_map[make]="make.x86_64"
+package_map[wget]="wget.x86_64"
+package_map[openssl-devel]="openssl-devel.i686"
+package_map[bzip2-devel]="bzip2-devel.i686"
+package_map[libffi-devel]="libffi-devel.i686"
+package_map[zlib-devel]="zlib-devel.i686"
+package_map[xz-devel]="xz-devel.i686"
+package_map[procps-ng]="procps-ng.i686"
+
+# Declare an associative array keyed by the generic package name to install, with
+# a value of all the architecture packages expected to be found if installed.
+declare -A py_pkg_map
+py_pkg_map[pip]="pip"
+py_pkg_map[wheel]="wheel"
+py_pkg_map[uwsgi]="uWSGI"
+
+# Use emojis while tracking verification steps if the LANG
+# environment variable is set to 'UTF-8' or 'utf8' (case-insensitive).
+declare -A emoji_map
+if echo "$LANG" | grep -iEq 'utf[-]?8' > /dev/null; then
+    # Locale is UTF-8 compatible, set emojis
+    emoji_map[key]='🔑'
+    emoji_map[pkg]='📦'
+    emoji_map[success]='✅'
+else
+    # Locale is not UTF-8 compatible, set empty strings
+    emoji_map[key]=''
+    emoji_map[pkg]=''
+    emoji_map[success]=''
+fi
+
+# grab the list of installed packages to search
+DNF_LIST_OUTPUT=$(dnf list 2>/dev/null)
+
+echo Make sure subscription-manager.conf changes in place
+echo "${emoji_map[key]}Check if suppressing of entitlements is configured..."
+grep -Pzo '\[main\]\nenabled=0\n' /etc/dnf/plugins/subscription-manager.conf > /dev/null
+[ $? -eq 0 ] && echo "...${emoji_map[success]}okay!";
+echo "${emoji_map[key]}Check if external repos enabled regardless of subscription..."
+grep -Pzo '\ndisable_system_repos=0' /etc/dnf/plugins/subscription-manager.conf > /dev/null
+[ $? -eq 0 ] && echo "...${emoji_map[success]}okay!";
+
+echo Make sure expected packages have been installed with dnf
+for package_key in "${!package_map[@]}"; do
+    echo "${emoji_map[key]}Check if ${package_key} (Generic Name) installed..."
+    # Get the string containing all space-separated values for the current key
+    package_values="${package_map[${package_key}]}"
+    for arch_value in ${package_values}; do
+	echo -n "   ${emoji_map[pkg]}looking for ${arch_value}"
+	grep -E "^${arch_value}[[:space:]].*$" > /dev/null <<< "$DNF_LIST_OUTPUT"
+	[ $? -eq 0 ] && echo "...${emoji_map[success]}found!";
+    done
+done
+
+echo Make sure expected Python packages have been installed with pip
+# grab the list of installed packages to search
+PIP_LIST_OUTPUT=$(/usr/local/bin/pip3.13 list --no-cache-dir 2> /dev/null)
+for py_pkg_key in "${!py_pkg_map[@]}"; do
+    echo "${emoji_map[key]}Check if ${py_pkg_key} Python package installed..."
+    # Get the string containing all space-separated values for the current key
+    package_values="${py_pkg_map[${py_pkg_key}]}"
+    for pkg_name in ${package_values}; do
+	echo -n "   ${emoji_map[pkg]}looking for ${pkg_name}"
+	grep -E "^${pkg_name}[[:space:]].*$" > /dev/null <<< "$PIP_LIST_OUTPUT"
+	[ $? -eq 0 ] && echo "...${emoji_map[success]}found!";
+    done
+done
+
+# @TODO Make sure alternatives settings and shell-user aliases are as expected
+# /etc/profile.d/uwsgi_python.sh
+# which python3 python pip3 pip
+
+# @TODO Make sure su-exec installed and usable by root
+# su-exec --help
+# Usage: su-exec user-spec command [args]
+# su-exec hive ls
+# su-exec: getpwnam(hive): Success
+
+echo No verification errors trapped. Checked results are as expected.
+exit 0

--- a/verify_install.sh
+++ b/verify_install.sh
@@ -10,12 +10,12 @@ package_map[gcc]="gcc.x86_64"
 package_map[git]="git.x86_64 git-core.x86_64"
 package_map[make]="make.x86_64"
 package_map[wget]="wget.x86_64"
-package_map[openssl-devel]="openssl-devel.i686"
-package_map[bzip2-devel]="bzip2-devel.i686"
-package_map[libffi-devel]="libffi-devel.i686"
-package_map[zlib-devel]="zlib-devel.i686"
-package_map[xz-devel]="xz-devel.i686"
-package_map[procps-ng]="procps-ng.i686"
+package_map[openssl-devel]="openssl-devel.x86_64"
+package_map[bzip2-devel]="bzip2-devel.x86_64"
+package_map[libffi-devel]="libffi-devel.x86_64"
+package_map[zlib-devel]="zlib-ng-compat-devel.x86_64"
+package_map[xz-devel]="xz-devel.x86_64"
+package_map[procps-ng]="procps-ng.x86_64"
 
 # Declare an associative array keyed by the generic package name to install, with
 # a value of all the architecture packages expected to be found if installed.

--- a/verify_uwsgi.sh
+++ b/verify_uwsgi.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+#set -x  # show commands as they execute
+
+APP_DIR=/tmp/uwsgi_test_app
+mkdir -p "$APP_DIR"
+cd "$APP_DIR"
+
+# Create a minimal WSGI app
+cat > test_wsgi.py <<'EOF'
+def app(environ, start_response):
+    import sys
+    start_response("200 OK", [("Content-Type", "text/plain")])
+    return [f"Python version: {sys.version}\n".encode()]
+EOF
+
+# uwsgi.ini forcing Python 3.13
+cat > uwsgi.ini <<'EOF'
+[uwsgi]
+module = test_wsgi:app
+http-socket = :8080
+master = true
+processes = 1
+threads = 1
+pythonpath = /usr/local/bin/python3.13
+enable-threads = true
+vacuum = true
+die-on-term = true
+EOF
+
+echo "=== Starting uWSGI with Python 3.13 ==="
+/usr/local/python3.13/bin/uwsgi --ini uwsgi.ini &
+UWSGI_PID=$!
+
+# Give uWSGI a moment to start
+sleep 3
+
+echo "=== Querying uWSGI ==="
+curl -s http://localhost:8080 | tee /tmp/uwsgi_python.txt
+
+echo "=== Checking that uWSGI is using Python 3.13 ==="
+if grep -q '3\.13' /tmp/uwsgi_python.txt; then
+    echo "✅ uWSGI is using Python 3.13"
+else
+    echo "❌ uWSGI is NOT using Python 3.13"
+    exit 1
+fi
+
+# Cleanup
+kill "$UWSGI_PID" || true
+wait "$UWSGI_PID" 2>/dev/null || true
+rm -rf "$APP_DIR"
+
+echo "=== Checking system Python version ==="
+
+/usr/bin/python3 --version | grep -E "^Python 3.12.[0-9][0-9]*$" > /dev/null
+[ $? -eq 0 ] && echo "✅ system Python at /usr/bin/python3 is set to `/usr/bin/python3 --version`."
+


### PR DESCRIPTION
Initial release of version 1.2.0 which switches to UBI10, version 10.0, has Python 3.12 as its system Python (with less security vulnerabilities than UBI9), and has Python 3.13 dual-installed for use by uWSGI.