### PR TITLE
Retain git in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -126,8 +126,8 @@ RUN set -eux && \
     echo 'alias pip=/usr/local/bin/pip3.13' >> /etc/profile.d/uwsgi_python.sh
 
 # Install su-exec for de-elevating root to hive user while running services, and
-# remove packages which were only needed by the preceding steps and not by
-# services running in uWSGI.
+# remove packages which were only needed by the preceding steps and not to
+# run or build uWSGI services.
 RUN set -eux && \
     # Install what is needed to retrieve and build su-exec
     dnf install --assumeyes procps-ng make gcc git wget && \
@@ -137,7 +137,7 @@ RUN set -eux && \
     make -C /tmp/su-exec && \
     install -m 755 /tmp/su-exec/su-exec /usr/local/bin/su-exec && \
     # Clean up artifacts to slim down this layer of the Docker Image
-    dnf remove --assumeyes procps-ng make gcc git wget && \
+    dnf remove --assumeyes procps-ng make gcc wget && \
     dnf autoremove --assumeyes && \
     dnf clean all && \
     rm -rf /tmp/su-exec \


### PR DESCRIPTION
Retain git in Dockerfile for services leveraging the git client to clone repositories.